### PR TITLE
fix(vmcontroller): VM must be RUNNING state when restored

### DIFF
--- a/boxer/internal/vmcontroller/vmcontroller.go
+++ b/boxer/internal/vmcontroller/vmcontroller.go
@@ -255,6 +255,6 @@ func (vc *vmController) RestoreSnapshot(vctx *VMContext) (err error) {
 		}
 	}
 	// Set the VM state to STOPPED after restoring snapshot
-	vctx.setState(vmstate.STOPPED)
+	vctx.setState(vmstate.RUNNING)
 	return nil
 }


### PR DESCRIPTION
When restore VM, it turned on after that.

But boxer set VM state to stopped.